### PR TITLE
Parameterizing ami version for upstream compatibility

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -18,7 +18,7 @@ data "aws_iam_policy_document" "workers_assume_role_policy" {
 data "aws_ami" "eks_worker" {
   filter {
     name   = "name"
-    values = ["amazon-eks-node-${var.cluster_version}-v20181210"]
+    values = ["amazon-eks-node-${var.cluster_version}-v${var.ami_version}"]
   }
 
   most_recent = true

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,11 @@ variable "cluster_version" {
   default     = "1.10"
 }
 
+variable "ami_version" {
+  description = "Version for the EKS-optimized worker AMI."
+  default     = "*"
+}
+
 variable "config_output_path" {
   description = "Determines where config files are placed if using configure_kubectl_session and you want config files to land outside the current working directory. Should end in a forward slash / ."
   default     = "./"


### PR DESCRIPTION
Parameterizing the AMI version for the EKS worker AMI so it's more compatible upstream merge. Assuming most folks aren't rolling their cluster as often as we are, this allows them to continue to select the latest version of the image at initial deploy time via the globstar while maintaining the ability to pin the version to prevent rolling nodes from other changes accidentally.